### PR TITLE
Add email send button and cleanup DB references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Formulário interativo e responsivo para coleta de dados sobre cefaleias (dores 
 - 💾 Salvamento automático de rascunho
 - 📊 Geração de relatório formatado
 - 🖨️ Impressão otimizada
+- 📧 Envio fácil por e-mail do relatório
 - 📱 Design responsivo
 - 🎨 Interface moderna e intuitiva
-- 🗄️ Banco de dados SQLite integrado
-- 📈 Dashboard com estatísticas e visualização de respostas
+- 📈 Dashboard opcional com estatísticas
 - 🧠 **NOVO:** Escalas MIDAS e GAD-7 integradas com cálculo automático
 - ⚡ **NOVO:** Validações inteligentes e campos exclusivos
 - 🔄 **NOVO:** Sub-perguntas dinâmicas baseadas nas respostas
@@ -75,42 +75,6 @@ Formulário interativo e responsivo para coleta de dados sobre cefaleias (dores 
 
 4. **Pronto!** Seu site estará online
 
-## 🚀 Deploy com Banco de Dados
-
-### Railway (Recomendado - Grátis com limites)
-
-1. **Crie conta no Railway:** https://railway.app
-
-2. **Instale Railway CLI:**
-   ```bash
-   npm i -g @railway/cli
-   ```
-
-3. **Na pasta do projeto:**
-   ```bash
-   railway login
-   railway init
-   railway up
-   ```
-
-4. **Configure a porta:**
-   - No dashboard do Railway, vá em Settings
-   - Adicione variável: `PORT = 3000`
-   - Generate Domain para obter URL pública
-
-### Render (Alternativa Gratuita)
-
-1. **Crie conta:** https://render.com
-
-2. **Conecte seu GitHub**
-
-3. **New > Web Service**
-
-4. **Configure:**
-   - Build Command: `npm install`
-   - Start Command: `npm start`
-
-5. **Deploy!** URL gerada automaticamente
 
 ## 📁 Estrutura do Projeto
 
@@ -120,11 +84,8 @@ formulario-cefaleia/
 ├── dashboard.html  # Dashboard de visualização
 ├── styles.css      # Estilos do formulário
 ├── script.js       # Lógica do formulário
-├── server.js       # Servidor Express
-├── database.js     # Configuração SQLite
 ├── package.json    # Dependências Node.js
 ├── .gitignore      # Arquivos ignorados
-├── cefaleia.db     # Banco de dados (criado automaticamente)
 └── README.md       # Este arquivo
 ```
 
@@ -134,26 +95,8 @@ formulario-cefaleia/
 1. Baixe todos os arquivos
 2. Abra `index.html` no navegador
 3. Pronto para usar!
+4. Após preencher, clique em **Baixar PDF** e depois em **Enviar por E-mail** para anexar o arquivo e enviá-lo ao médico.
 
-### Com Banco de Dados (Formulário + Dashboard)
-
-1. **Instale o Node.js** (se não tiver): https://nodejs.org
-
-2. **Na pasta do projeto, instale as dependências:**
-   ```bash
-   npm install
-   ```
-
-3. **Inicie o servidor:**
-   ```bash
-   npm start
-   ```
-
-4. **Acesse no navegador:**
-   - Formulário: http://localhost:3000
-   - Dashboard: http://localhost:3000/dashboard
-
-5. **Pronto!** O banco de dados será criado automaticamente (arquivo `cefaleia.db`)
 
 ## 🛠️ Personalização
 

--- a/script.js
+++ b/script.js
@@ -282,6 +282,9 @@ function mostrarTelaPaciente(id, timestamp) {
                      <button onclick="baixarPDF()" class="btn btn-primary" style="margin-right: 10px;">
                          📄 Baixar PDF do Questionário
                      </button>
+                     <button onclick="enviarEmail()" class="btn btn-success" style="margin-right: 10px;">
+                         📧 Enviar por E-mail
+                     </button>
                      <button onclick="mostrarAreaAdmin()" class="btn btn-secondary" style="margin-right: 10px;">
                          🔐 Área do Médico
                      </button>
@@ -334,6 +337,9 @@ function mostrarTelaPacienteOffline(timestamp, formData) {
                                  <div style="margin-top: 30px;">
                      <button onclick="baixarPDF()" class="btn btn-primary" style="margin-right: 10px;">
                          📄 Baixar PDF do Questionário
+                     </button>
+                     <button onclick="enviarEmail()" class="btn btn-success" style="margin-right: 10px;">
+                         📧 Enviar por E-mail
                      </button>
                      <button onclick="voltarFormulario()" class="btn" style="background: #6b7280; color: white;">
                          ← Novo Questionário
@@ -432,19 +438,29 @@ function verificarPaginaResultado() {
                                 ${dados.id === 'OFFLINE' ? '<p style="color: #dc2626 !important; font-size: 14px !important;">⚠️ Não foi possível salvar no banco de dados, mas você pode baixar o PDF.</p>' : '<p style="color: #166534 !important; font-size: 14px !important;">O Dr. Thales receberá sua resposta.</p>'}
                                 <div style="margin-top: 30px !important;">
                                     <button onclick="baixarPDF()" style="
-                                        padding: 12px 24px !important; 
-                                        background: #3b82f6 !important; 
-                                        color: white !important; 
-                                        border: none !important; 
-                                        border-radius: 8px !important; 
+                                        padding: 12px 24px !important;
+                                        background: #3b82f6 !important;
+                                        color: white !important;
+                                        border: none !important;
+                                        border-radius: 8px !important;
                                         cursor: pointer !important;
                                         margin-right: 10px !important;
                                         font-size: 16px !important;
                                     ">📄 Baixar PDF</button>
+                                    <button onclick="enviarEmail()" style="
+                                        padding: 12px 24px !important;
+                                        background: #10b981 !important;
+                                        color: white !important;
+                                        border: none !important;
+                                        border-radius: 8px !important;
+                                        cursor: pointer !important;
+                                        margin-right: 10px !important;
+                                        font-size: 16px !important;
+                                    ">📧 Enviar por E-mail</button>
                                     <button onclick="voltarFormulario()" style="
-                                        padding: 12px 24px !important; 
-                                        background: #6b7280 !important; 
-                                        color: white !important; 
+                                        padding: 12px 24px !important;
+                                        background: #6b7280 !important;
+                                        color: white !important;
                                         border: none !important; 
                                         border-radius: 8px !important; 
                                         cursor: pointer !important;
@@ -1335,6 +1351,19 @@ function baixarPDF() {
     // Salvar PDF
     const nomeArquivo = `questionario_cefaleia_${dadosSalvos.id}_${new Date().toISOString().split('T')[0]}.pdf`;
     doc.save(nomeArquivo);
+}
+
+// Abrir cliente de email com informações básicas
+function enviarEmail() {
+    const dadosSalvos = JSON.parse(sessionStorage.getItem('relatorio_completo'));
+    if (!dadosSalvos) {
+        alert('Salve o PDF antes de enviar.');
+        return;
+    }
+
+    const assunto = encodeURIComponent('Questionário de Cefaleia');
+    const corpo = encodeURIComponent(`Olá Dr. Thales,%0D%0Asegue em anexo o PDF do meu questionário.%0D%0AID: ${dadosSalvos.id}%0D%0AData: ${dadosSalvos.timestamp}`);
+    window.location.href = `mailto:dr.thales@example.com?subject=${assunto}&body=${corpo}`;
 }
 
 // Configurar exclusividade entre número exato e opções múltiplas


### PR DESCRIPTION
## Summary
- make PDF sendable by email after submission
- add offline email button
- update README to remove database deployment steps
- document how to send PDF by email

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889fdab59b0832b82257d435d0f5928